### PR TITLE
Fix erlang uninstallation cleanup

### DIFF
--- a/bin/uninstall
+++ b/bin/uninstall
@@ -7,7 +7,7 @@ source "$(dirname $0)/utils.sh"
 ensure_kerl_setup
 
 # Remove the installation and build if the installation was done by kerl
-if $(kerl_path) list installation | grep "$ASDF_INSTALL_PATH"; then
+if $(kerl_path) list installations | grep "$ASDF_INSTALL_PATH"; then
     $(kerl_path) delete build "asdf_$ASDF_INSTALL_VERSION"
     $(kerl_path) delete installation "$ASDF_INSTALL_PATH"
 fi


### PR DESCRIPTION
The kerl command is `installations`, with an **s**.